### PR TITLE
Remove University of Sheffield provider

### DIFF
--- a/src/main/resources/config-others.xml
+++ b/src/main/resources/config-others.xml
@@ -159,8 +159,8 @@
 	      name="Information Retrieval Facility"/>
     <!--<provider url="http://nactem.ac.uk/software/Farm/oai/oai.pl"
 	      name="National Centre for Text Mining NaCTeM"/>-->
-    <provider url="http://services.gate.ac.uk/oai"
-	      name="University of Sheffield"/>
+    <!--<provider url="http://services.gate.ac.uk/oai"
+	      name="University of Sheffield"/>-->
     <provider url="http://sag.art.uniroma2.it/oai/oai.pl"
 	      name="University of Roma Tor Vergata"/>
     <provider url="http://redac.univ-tlse2.fr/metadata/oai/oai.pl"


### PR DESCRIPTION
@dietervu  reported:
>All these links no longer work. We should probably remove the Sheffield OAI provider.
See https://support.clarin-d.de/otrs/index.pl?Action=AgentTicketZoom;TicketID=4082#17031