### PR TITLE
Fix moving of directories to output dir

### DIFF
--- a/src/main/scripts/oai_harvest.py
+++ b/src/main/scripts/oai_harvest.py
@@ -303,9 +303,9 @@ class OaiHarvest:
 
     def search(self, directory):
         """
-        Search all leaf directories in the specified directory
+        Search all directories in the specified directory
         """
-        result = self.find(directory, "-mindepth", "1", "-type", "d")
+        result = self.find(directory, "-mindepth", "1", "-maxdepth", "1", "-type", "d")
         return result.splitlines()
 
     def do_rsync(self, source, destination):


### PR DESCRIPTION
Moving of harvested files to output directory: only move direct children to prevent duplicates in output directory to prevent issue with output distributed over multiple directories in cases where`max-files` is set.