### PR TITLE
Free up action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
     <!-- REPOSITORIES -->
     <repositories>
         <repository>
+            <id>huygens-maven</id>
+            <name>Huygens Maven</name>
+            <url>https://maven.huygens.knaw.nl/repository</url>
+        </repository>
+        <repository>
             <id>CLARIN</id>
             <name>CLARIN Repository</name>
             <url>https://nexus.clarin.eu/content/repositories/Clarin</url>
@@ -166,7 +171,6 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.4.0-b180725.0644</version>
         </dependency>
-    
     </dependencies>
 
     <!-- Build cycle referred plugins -->

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+module oai.harvest.manager {
+    exports nl.mpi.oai.harvester.action;
+    exports nl.mpi.oai.harvester.metadata;
+    requires Saxon.HE;
+    requires SaxonUtils;
+    requires org.apache.logging.log4j;
+    requires stax2.api;
+    requires java.xml;
+    requires java.management;
+    requires org.joda.time;
+    requires java.xml.bind;
+    requires org.apache.commons.io;
+    requires xalan;
+    requires json.path;
+    requires com.google.common;
+    requires java.logging;
+    requires woodstox.core.asl;
+    requires json.smart;
+}

--- a/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
@@ -117,7 +117,7 @@ public class Configuration {
     /**
      * Map file
      */
-    
+
     private String mapFile = "map.csv";
 
     /**
@@ -343,24 +343,24 @@ public class Configuration {
         if (importNode == null) {
             logger.debug("No import node in the configuration file");
         } else {
-            final Node includeSetTypesNode = (Node) xpath.evaluate("./includeOaiPmhSetTypes", importNode,XPathConstants.NODE);
+            final Node includeSetTypesNode = (Node) xpath.evaluate("./includeOaiPmhSetTypes", importNode, XPathConstants.NODE);
             final Collection<String> includeSetTypes;
-            if(includeSetTypesNode != null) {
+            if (includeSetTypesNode != null) {
                 includeSetTypes = Splitter.onPattern("\\s*,\\s*").splitToList(includeSetTypesNode.getTextContent());
             } else {
-                 includeSetTypes= DEFAULT_INCLUDE_SETS;
+                includeSetTypes = DEFAULT_INCLUDE_SETS;
             }
             logger.debug("Included set types: {}", includeSetTypes);
-            
-            final Node excludeSetTypesNode = (Node) xpath.evaluate("./excludeOaiPmhSetTypes", importNode,XPathConstants.NODE);
+
+            final Node excludeSetTypesNode = (Node) xpath.evaluate("./excludeOaiPmhSetTypes", importNode, XPathConstants.NODE);
             final Collection<String> excludeSetTypes;
-            if(excludeSetTypesNode != null) {
+            if (excludeSetTypesNode != null) {
                 excludeSetTypes = Splitter.onPattern("\\s*,\\s*").splitToList(excludeSetTypesNode.getTextContent());
             } else {
                 excludeSetTypes = DEFAULT_EXCLUDE_SETS;
             }
             logger.debug("Excluded set types: {}", excludeSetTypes);
-            
+
             // within the import node, look for the mandatory registry node   
             Node registryNode = (Node) xpath.evaluate("./registry", importNode,
                     XPathConstants.NODE);
@@ -376,7 +376,7 @@ public class Configuration {
                 } else {
 
                     logger.info("Importing providers from registry at {}", rUrl);
-                    
+
                     // list of endpoints to be excluded
                     ArrayList<String> excludeSpec = new ArrayList<>();
 
@@ -414,7 +414,7 @@ public class Configuration {
                     }
                     // get the list of endpoints from the centre registry
                     registryReader = new RegistryReader(new java.net.URL(rUrl));
-                    final Map<String, Collection<CentreRegistrySetDefinition>> endPointOaiPmhSetMap 
+                    final Map<String, Collection<CentreRegistrySetDefinition>> endPointOaiPmhSetMap
                             = registryReader.getEndPointOaiPmhSetMap();
 
                     // use the list to create the list of endpoints to harvest from
@@ -453,32 +453,32 @@ public class Configuration {
                                 provider.setIncremental(isIncremental());
                                 provider.setScenario(getScenario());
                             }
-                            
+
                             //configure sets
                             final Collection<CentreRegistrySetDefinition> allSets
                                     = Optional.ofNullable(endPointOaiPmhSetMap.get(provUrl))
-                                            .orElse(Collections.emptySet());
-                            
-                            if(!allSets.isEmpty()) {
+                                    .orElse(Collections.emptySet());
+
+                            if (!allSets.isEmpty()) {
                                 //apply include/exclude config
                                 final Collection<CentreRegistrySetDefinition> includedSets
                                         = new HashSet<>(allSets);
-                                if(!includeSetTypes.contains("*")) {
+                                if (!includeSetTypes.contains("*")) {
                                     //reduce to entries with type matching entry from include types
                                     includedSets.removeIf(
                                             Predicates.not(s -> includeSetTypes.contains(s.getSetType())));
-                                }                            
-                                if(!excludeSetTypes.isEmpty()) {
+                                }
+                                if (!excludeSetTypes.isEmpty()) {
                                     includedSets.removeIf(s -> excludeSetTypes.contains(s.getSetType()));
-                                }                            
+                                }
 
                                 logger.debug("Sets for {}; before include/exclude filter: {}; after filter: {}", provUrl, allSets, includedSets);
 
-                                if(!includedSets.isEmpty()) {
+                                if (!includedSets.isEmpty()) {
                                     final String[] sets = includedSets.stream()
                                             .map(CentreRegistrySetDefinition::getSetSpec)
                                             .toArray(String[]::new);
-                                    if(sets.length > 0) {
+                                    if (sets.length > 0) {
                                         provider.setSets(sets);
                                     }
                                 }
@@ -506,9 +506,9 @@ public class Configuration {
 
             int timeout = (pTimeout != null) ? Integer.valueOf(pTimeout) : getTimeout();
             int maxRetryCount = (pMaxRetryCount != null) ? Integer.valueOf(pMaxRetryCount) : getMaxRetryCount();
-            int[] retryDelays = (pRetryDelays != null)?parseRetryDelays(pRetryDelays):getRetryDelays();
+            int[] retryDelays = (pRetryDelays != null) ? parseRetryDelays(pRetryDelays) : getRetryDelays();
             boolean exclusive = Boolean.parseBoolean(pExclusive);
-            String scenario = (pScenario != null) ?  pScenario : getScenario();
+            String scenario = (pScenario != null) ? pScenario : getScenario();
 
             if (pUrl == null) {
                 logger.error("Skipping provider " + pName + ": URL is missing");
@@ -578,7 +578,7 @@ public class Configuration {
             return "workspace";
         return s;
     }
-    
+
     public Map<String, OutputDirectory> getOutputDirectories() {
         return outputs;
     }
@@ -593,7 +593,7 @@ public class Configuration {
         if (s == null) return new int[]{0};
         String[] sa = s.split("\\s+");
         int[] da = new int[sa.length];
-        for (int i=0;i<sa.length;i++)
+        for (int i = 0; i < sa.length; i++)
             da[i] = Integer.valueOf(sa[i]);
         return da;
     }
@@ -648,12 +648,12 @@ public class Configuration {
         if (!Files.exists(p)) {
             PrintWriter map = null;
             try {
-                map = new PrintWriter(new FileWriter(mapFile,true));
+                map = new PrintWriter(new FileWriter(mapFile, true));
                 map.println("endpointUrl,directoryName,centreName,nationalProject");
             } catch (IOException e) {
                 logger.error("couldn't create an initial/default " + mapFile + " file: ", e);
             } finally {
-                if (map!=null)
+                if (map != null)
                     map.close();
             }
         }
@@ -713,7 +713,7 @@ public class Configuration {
             logger.warn("Incremental harvesting cannot be enabled ... needs to be finished!");
         return false;
     }
-    
+
     /**
      * Get dry run flag.
      */
@@ -721,7 +721,7 @@ public class Configuration {
         String s = settings.get(KnownOptions.DRYRUN.toString());
         return (s == null) ? false : Boolean.valueOf(s);
     }
-    
+
     /**
      * Get scenario.
      */
@@ -729,21 +729,21 @@ public class Configuration {
         String s = settings.get(KnownOptions.SCENARIO.toString());
         return (s == null) ? "ListIndentifiers" : s;
     }
-    
+
     /**
      * Get Registry Reader
      */
     public RegistryReader getRegistryReader() {
         return this.registryReader;
     }
-    
+
     /**
      * Has a Registry Reader?
      */
     public boolean hasRegistryReader() {
-        return (this.registryReader!=null);
+        return (this.registryReader != null);
     }
-    
+
 
     /**
      * Log parsed contents of the configuration.

--- a/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
@@ -251,18 +251,25 @@ public class Configuration {
             InvocationTargetException {
 
 //        TODO: fall back to Class.forName when file is not provided
-        // use ArrayList to add URL to Array
-        URL[] urls = new URL[0];
-        ArrayList<URL> urlArrayList = new ArrayList<>(Arrays.asList(urls));
-        urlArrayList.add(new URL("jar:file:" + file + "!/"));
-        urls = urlArrayList.toArray(urls);
+        Class<?> cls;
+        if (file == null) {
+            logger.info("No jar file given, loading from class path;");
+            cls = Class.forName(className);
+        } else {
+            // use ArrayList to add URL to Array
+            URL[] urls = new URL[0];
+            ArrayList<URL> urlArrayList = new ArrayList<>(Arrays.asList(urls));
+            urlArrayList.add(new URL("jar:file:" + file + "!/"));
+            urls = urlArrayList.toArray(urls);
 
-        // init class loader from all the JARs
-        URLClassLoader cl = URLClassLoader.newInstance(urls);
+            // init class loader from all the JARs
+            URLClassLoader cl = URLClassLoader.newInstance(urls);
 
-        className = className.replace('/', '.');
-        logger.info("Loading class [" + className + "].");
-        Class<?> cls = cl.loadClass(className);
+            className = className.replace('/', '.');
+            logger.info("Loading class [" + className + "].");
+            cls = cl.loadClass(className);
+        }
+        
         try {
             return (Action) cls.getDeclaredConstructor().newInstance();
         } catch (ClassCastException ex) {

--- a/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
@@ -235,7 +235,7 @@ public class Configuration {
     }
 
     /**
-     * Load and return the designated action from a given jar file either on disk or from URL.
+     * Load and return the designated action from a given jar file either on disk.
      * If the type casting gives an error, null will be returned which will be handled by the caller.
      *
      * @param file      The string value of the jar file path
@@ -250,7 +250,6 @@ public class Configuration {
             NoSuchMethodException,
             InvocationTargetException {
 
-//        TODO: fall back to Class.forName when file is not provided
         Class<?> cls;
         if (file == null) {
             logger.info("No jar file given, loading from class path;");

--- a/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
@@ -21,7 +21,6 @@ package nl.mpi.oai.harvester.control;
 import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
-import net.sf.saxon.expr.CastableExpression;
 import nl.mpi.oai.harvester.Provider;
 import nl.mpi.oai.harvester.StaticProvider;
 import nl.mpi.oai.harvester.action.*;
@@ -53,9 +52,17 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Arrays;
+
 
 /**
  * This class represents the settings of the application as defined in its
@@ -91,12 +98,6 @@ public class Configuration {
      * centre registry).
      */
     private List<Provider> providers;
-
-    /**
-     * All known actions
-     */
-    private List<String> knownActions = Arrays.asList("strip", "split", "save", "transform");
-
 
     /**
      * List of names of known configuration options.
@@ -369,8 +370,7 @@ public class Configuration {
                             logger.error(ex);
                         }
                     } else {
-                        // load external actions according to the config file, from jar, and execute them
-                        // first, load jar from jar location
+                        // load external actions according to the config file, from jar
                         String jarLocation = Util.getNodeText(xpath, "./@file", s);
                         logger.info("jar found in " + jarLocation);
                         try {

--- a/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Configuration.java
@@ -235,21 +235,6 @@ public class Configuration {
     }
 
     /**
-     * Check if given URL is valid
-     * @param url The URL to be checked
-     * @return true if valid, otherwise false
-     */
-    private boolean isValidUrl(String url) {
-        try {
-            URL obj = new URL(url);
-            obj.toURI();
-            return true;
-        } catch (MalformedURLException | URISyntaxException e) {
-            return false;
-        }
-    }
-
-    /**
      * Load and return the designated action from a given jar file either on disk or from URL.
      * If the type casting gives an error, null will be returned which will be handled by the caller.
      *
@@ -265,14 +250,11 @@ public class Configuration {
             NoSuchMethodException,
             InvocationTargetException {
 
+//        TODO: fall back to Class.forName when file is not provided
         // use ArrayList to add URL to Array
         URL[] urls = new URL[0];
         ArrayList<URL> urlArrayList = new ArrayList<>(Arrays.asList(urls));
-        if (isValidUrl(file)) {
-            urlArrayList.add(new URL(file));
-        } else {
-            urlArrayList.add(new URL("jar:file:" + file + "!/"));
-        }
+        urlArrayList.add(new URL("jar:file:" + file + "!/"));
         urls = urlArrayList.toArray(urls);
 
         // init class loader from all the JARs

--- a/src/main/java/nl/mpi/oai/harvester/control/Main.java
+++ b/src/main/java/nl/mpi/oai/harvester/control/Main.java
@@ -47,7 +47,7 @@ public class Main {
 
     private static void runHarvesting(Configuration config) {
 	config.log();
-        
+
         ExecutorService executor = new ScheduledThreadPoolExecutor(config.getMaxJobs());
 
 	// create a CycleFactory
@@ -61,23 +61,23 @@ public class Main {
 	    Worker worker = new Worker(provider, config, cycle);
             executor.execute(worker);
 	}
-        
+
         executor.shutdown();
     }
 
     public static void main(String[] args) {
-        
+
         logger.info("Welcome to the main OAI Harvest Manager!");
-        
+
 	String configFile = null;
 
 	// Select Saxon XSLT/XPath implementation (necessary in case there
         // are other XSLT/XPath libraries in classpath).
-        System.setProperty("javax.xml.transform.TransformerFactory",    
+        System.setProperty("javax.xml.transform.TransformerFactory",
             "net.sf.saxon.TransformerFactoryImpl");
         System.setProperty("javax.xml.xpath.XPathFactory",
             "net.sf.saxon.xpath.XPathFactoryImpl");
-    
+
         // Some endpoints behave differently when you're not a browser, so fake it
         System.setProperty("http.agent",
             "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
@@ -99,7 +99,7 @@ public class Main {
 	}
 
 	// Process options given on the command line (if any), then read the
-	// configuration file. 
+	// configuration file.
 	config = new Configuration();
 	for (String arg : args) {
 	    if (arg.indexOf('=') > -1) {
@@ -113,17 +113,20 @@ public class Main {
 	}
 	try {
 	    config.readConfig(configFile);
-	} catch (ParserConfigurationException | SAXException 
+	} catch (ParserConfigurationException | SAXException
 		| XPathExpressionException | IOException ex) {
 	    logger.error("Unable to read configuration file", ex);
 	    return;
+	} catch (ClassNotFoundException ex) {
+		logger.error("One or more classes cannot be found", ex);
+		return;
 	}
 
 	// Ensure the timeout setting is honored.
 	config.applyTimeoutSetting();
 
 	runHarvesting(config);
-        
+
         logger.info("Goodbye from the main OAI Harvest Manager!");
 
     }

--- a/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
+++ b/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
@@ -91,7 +91,7 @@ public class ConfigurationTest {
         assertEquals("http://www.clarin.eu/cmd/1", actionSequences.get(0).getInputFormat().getValue());
         
         final List<ResourcePool<Action>> actions = actionSequences.get(0).getActions();
-        assertEquals(5, actions.size());
+        assertEquals(6, actions.size());
         
     }
 

--- a/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
+++ b/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
@@ -92,7 +92,6 @@ public class ConfigurationTest {
         
         final List<ResourcePool<Action>> actions = actionSequences.get(0).getActions();
         assertEquals(6, actions.size());
-        
     }
 
     @Test

--- a/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
+++ b/src/test/java/nl/mpi/oai/harvester/control/ConfigurationTest.java
@@ -91,7 +91,7 @@ public class ConfigurationTest {
         assertEquals("http://www.clarin.eu/cmd/1", actionSequences.get(0).getInputFormat().getValue());
         
         final List<ResourcePool<Action>> actions = actionSequences.get(0).getActions();
-        assertEquals(6, actions.size());
+        assertEquals(7, actions.size());
     }
 
     @Test

--- a/src/test/resources/config/test-config-basic.xml
+++ b/src/test/resources/config/test-config-basic.xml
@@ -46,7 +46,7 @@
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="strip"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
-      <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="/Users/vic/Documents/DI/projects/oai-harvester-manager-action/target/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
+      <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="https://github.com/vicding-mi/oai-harvest-manager-action/releases/download/release/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">
       <action type="save" dir="oai" suffix=".xml"/>

--- a/src/test/resources/config/test-config-basic.xml
+++ b/src/test/resources/config/test-config-basic.xml
@@ -46,6 +46,7 @@
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="strip"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+      <action type="nl.mpi.oai.harvester.action.SplitAction" />
       <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="/Users/vic/Documents/DI/projects/oai-harvest-manager-action/target/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">

--- a/src/test/resources/config/test-config-basic.xml
+++ b/src/test/resources/config/test-config-basic.xml
@@ -46,6 +46,7 @@
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="strip"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+      <action type="nl.knaw.huc.di.sd.HelloWorldAction" />
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">
       <action type="save" dir="oai" suffix=".xml"/>

--- a/src/test/resources/config/test-config-basic.xml
+++ b/src/test/resources/config/test-config-basic.xml
@@ -46,7 +46,7 @@
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="strip"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
-      <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="https://github.com/vicding-mi/oai-harvest-manager-action/releases/download/release/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
+      <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="/Users/vic/Documents/DI/projects/oai-harvest-manager-action/target/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">
       <action type="save" dir="oai" suffix=".xml"/>

--- a/src/test/resources/config/test-config-basic.xml
+++ b/src/test/resources/config/test-config-basic.xml
@@ -46,7 +46,7 @@
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="strip"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
-      <action type="nl.knaw.huc.di.sd.HelloWorldAction" />
+      <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="/Users/vic/Documents/DI/projects/oai-harvester-manager-action/target/oai-harvester-manager-action-1.0-SNAPSHOT.jar" />
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">
       <action type="save" dir="oai" suffix=".xml"/>


### PR DESCRIPTION
This PR decouples the actions from the main package. After adoption of the package, extra actions can be invoked by adding particular actions to the config file

```
    <actions>
        <format match="prefix" value="http://www.clarin.eu/cmd/1">
...
            <action type="nl.knaw.huc.di.sd.HelloWorldAction" file="extra-actions.jar" />
            <action type="nl.mpi.oai.harvester.action.SplitAction" />
        </format>
    </actions>
```
The line `<action type="nl.knaw.huc.di.sd.HelloWorldAction" file="extra-actions.jar" />`, indicates a new action and informs where to get the jar contains the definition of it. 

`<action type="nl.mpi.oai.harvester.action.SplitAction" />` indicates that when there is no jar file given, the harvester will fall back to class path for action look up. The internal `split` action is used but called with its full qualified name. 

The action JAR should implement, for example
```
package nl.knaw.huc.di.sd;


import nl.mpi.oai.harvester.action.Action;
import nl.mpi.oai.harvester.metadata.Metadata;

import java.util.List;

public class HelloWorldAction implements Action {
    @Override
    public boolean perform(List<Metadata> list) {
        System.out.println("Hello World! Performing!");
        return false;
    }

    @Override
    public Action clone() {
        System.out.println("Hello World! Cloning!");
        return null;
    }
}

```
