### PR TITLE
fix on stream close too early

### DIFF
--- a/src/main/java/nl/mpi/oai/harvester/action/TransformAction.java
+++ b/src/main/java/nl/mpi/oai/harvester/action/TransformAction.java
@@ -258,6 +258,7 @@ public class TransformAction implements Action {
                     //res = resolver.resolve(request);
                     res = req.resolve(resolver);
                     Saxon.save(res, cacheDir.resolve(cacheFile).toFile());
+                    res = new StreamSource(cacheDir.resolve(cacheFile).toFile());
                     logger.debug("Transformer resolver: stored ["+cacheFile+"] in cache ["+cacheDir.resolve(cacheFile).toFile().toString()+"]");
                 } catch (Exception ex) {
                     throw new net.sf.saxon.trans.XPathException(ex);

--- a/src/main/java/nl/mpi/oai/harvester/action/TransformAction.java
+++ b/src/main/java/nl/mpi/oai/harvester/action/TransformAction.java
@@ -246,20 +246,21 @@ public class TransformAction implements Action {
                 logger.debug("Transformer resolver: loaded ["+cacheDir.resolve(cacheFile).toFile().toString()+"] from cache");
             } else {
                 try {
-                    if (resolver == null) 
+                    if (resolver == null)
                         resolver = new DirectResourceResolver(Saxon.getProcessor().getUnderlyingConfiguration());
-                    //ResourceRequest request = new ResourceRequest();
-                    //request.relativeUri = uri;
-                    //request.baseUri = base;
-                    //request.uri = uri;
-                    //request.nature = ResourceRequest.XML_NATURE;
-                    //request.purpose = ResourceRequest.ANY_PURPOSE;
-                    //res = request.resolve(resolver);
-                    //res = resolver.resolve(request);
-                    res = req.resolve(resolver);
-                    Saxon.save(res, cacheDir.resolve(cacheFile).toFile());
-                    res = new StreamSource(cacheDir.resolve(cacheFile).toFile());
+
+                    // Resolve the resource and immediately cache it to avoid stream closure issues
+                    Source resolvedSource = req.resolve(resolver);
+
+                    // Save to cache file immediately to buffer the entire content
+                    // This prevents "stream is closed" errors that occur when the HTTP connection
+                    // closes before the XML parser finishes reading
+                    Saxon.save(resolvedSource, cacheDir.resolve(cacheFile).toFile());
                     logger.debug("Transformer resolver: stored ["+cacheFile+"] in cache ["+cacheDir.resolve(cacheFile).toFile().toString()+"]");
+
+                    // Return a new Source pointing to the cached file
+                    // This ensures the parser reads from a file stream, not an HTTP stream that may be closed
+                    res = new StreamSource(cacheDir.resolve(cacheFile).toFile());
                 } catch (Exception ex) {
                     throw new net.sf.saxon.trans.XPathException(ex);
                 }


### PR DESCRIPTION
By reading from cached xml file instead of reading it from remote source each time, it saves time and eliminates the possibility of having remote source closed too early, which will result in an error and discontinue with the transformation. 

The problem comes from the particular way of using docker to load the local jar to for testing. It loads old version of jar even built successfully using mvn and docker. 

Both jdk 11 and 21 works well with the fix. This is tested with the official jdk 11 java base image and jdk 21 java based image (custom build with official java base).

Next step is to run the harvester container on an actual harvest config.  